### PR TITLE
Fix missing `#include <climits>` error on GCC

### DIFF
--- a/hhxx/bit.hpp
+++ b/hhxx/bit.hpp
@@ -5,6 +5,8 @@
 #ifndef HHXX_BIT_HPP_
 #define HHXX_BIT_HPP_
 
+#include <climits>
+
 #include <bitset>
 #include <type_traits>
 


### PR DESCRIPTION
nop